### PR TITLE
Extract all files

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,15 +173,17 @@
       h('p', {class:'persona-sub'}, i18n.t(meta.tag))
     ]));
 
-    main.appendChild(h('section', {}, [
-      h('h2', {}, i18n.t('quickActions')),
-      quickActions()
-    ]));
-
-    main.appendChild(h('section', {class:'section'}, [
-      h('h2', {}, i18n.t('recommended')),
-      personaRecommendations(slug)
-    ]));
+    const layout = h('div', {class:'persona-layout'}, [
+      h('aside', {class:'sidebar', role:'complementary', 'aria-label': i18n.t('quickActions')}, [
+        h('h2', {}, i18n.t('quickActions')),
+        quickActions()
+      ]),
+      h('section', {class:'section'}, [
+        h('h2', {}, i18n.t('recommended')),
+        personaRecommendations(slug)
+      ])
+    ]);
+    main.appendChild(layout);
   }
 
   function route(){

--- a/styles.css
+++ b/styles.css
@@ -47,3 +47,12 @@ body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,
 .modal-card{background:#fff;border-radius:16px;padding:20px;max-width:420px;width:100%;border:1px solid var(--border);box-shadow:var(--shadow)}
 .modal-title{font-size:22px;margin-bottom:8px}
 .modal-body{color:var(--muted);margin-bottom:12px}
+/* persona layout with sidebar */
+.persona-layout{display:grid;grid-template-columns:320px 1fr;gap:20px}
+.sidebar{position:sticky;top:20px;align-self:start;display:flex;flex-direction:column;gap:12px}
+.sidebar .actions{flex-direction:column}
+@media(max-width:900px){
+  .persona-layout{grid-template-columns:1fr}
+  .sidebar{position:relative;top:auto}
+  .sidebar .actions{flex-direction:row}
+}


### PR DESCRIPTION
Convert the "Quick Actions" section into a sticky side panel for persona views to improve UI layout.

The user requested to change the "young adult" panel from a top panel to a side panel. This refactors the persona view to use a two-column layout, placing quick actions in a dedicated, responsive sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-3153719c-3d4c-4379-96d0-4ec7d5f670a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3153719c-3d4c-4379-96d0-4ec7d5f670a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

